### PR TITLE
Use watch_cron_logs3.pl in the repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,21 +28,8 @@ TEST_DEP =
 test: check_install $(TEST_DEP) install
 
 install:
-	mkdir -p $(INSTALL_BIN); rsync --times --cvs-exclude $(BIN) $(INSTALL_BIN)/
-	mkdir -p $(INSTALL_DATA); rsync --times --cvs-exclude $(DATA) $(INSTALL_DATA)/
-	mkdir -p $(INSTALL_DOC)
-	pod2html watch_cron_logs.pl > $(INSTALL_DOC)/index.html
-	rm -f pod2htm?.tmp
-
-# Install watch_cron_logs3.pl using "skare3" convention: put into SKA_ARCH_OS/bin
-# and launched with /usr/bin/env perl instead of hardwired /usr/bin/env /proj/sot/ska/bin/perl
-install3:
-	echo '#!/usr/bin/env perl' > watch_cron_logs3.pl
-	tail -n +2 watch_cron_logs.pl >> watch_cron_logs3.pl
-	chmod +x watch_cron_logs3.pl
 	cp -p watch_cron_logs3.pl $(SKA_ARCH_OS)/bin/
-	rm watch_cron_logs3.pl
-
+	chmod +x $(SKA_ARCH_OS)/bin/watch_cron_logs3.pl
 
 clean:
 	rm -r bin data doc

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TASK = watch_cron_logs
 FLIGHT_ENV = SKA
 
 # Set the names of all files that get installed
-BIN = watch_cron_logs.pl
+BIN = watch_cron_logs3.pl
 DATA = default.config TST.config
 
 include /proj/sot/ska/include/Makefile.FLIGHT
@@ -27,9 +27,13 @@ TEST_DEP =
 # NO TESTs defined!
 test: check_install $(TEST_DEP) install
 
+
 install:
-	cp -p watch_cron_logs3.pl $(SKA_ARCH_OS)/bin/
-	chmod +x $(SKA_ARCH_OS)/bin/watch_cron_logs3.pl
+	mkdir -p $(INSTALL_BIN); rsync --times --cvs-exclude $(BIN) $(INSTALL_BIN)/
+	mkdir -p $(INSTALL_DATA); rsync --times --cvs-exclude $(DATA) $(INSTALL_DATA)/
+	mkdir -p $(INSTALL_DOC)
+	pod2html watch_cron_logs3.pl > $(INSTALL_DOC)/index.html
+	rm -f pod2htm?.tmp
 
 clean:
 	rm -r bin data doc

--- a/watch_cron_logs3.pl
+++ b/watch_cron_logs3.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perlska
+#!/usr/bin/env perl
 
 # Keep a 7-day daily archive of log outputs from cron jobs
 # 

--- a/watch_cron_logs3.pl
+++ b/watch_cron_logs3.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env /proj/sot/ska/bin/perl
+#!/usr/bin/env perlska
 
 # Keep a 7-day daily archive of log outputs from cron jobs
 # 


### PR DESCRIPTION
Use watch_cron_logs3.pl directly in the repo

This removes the skare3 Makefile hack (though in the case of watch_cron_logs.pl it doesn't look like it needs any SKA variables to be set).